### PR TITLE
Fix PT shift time export logic

### DIFF
--- a/generador_turnos_2025_cnx_BACKUP_F_FIRST_P_LAST (1).py
+++ b/generador_turnos_2025_cnx_BACKUP_F_FIRST_P_LAST (1).py
@@ -2195,14 +2195,11 @@ def export_detailed_schedule(assignments, shifts_coverage):
                         else:
                             horario = f"{int(start_hour):02d}:00-{end_hour_int:02d}:{end_minutes:02d}"
                     elif shift_name.startswith('PT'):
-                        # Para PT calcular horario usando el inicio declarado
-                        # y las horas reales trabajadas ese día
-                        daily_hours = len(work_hours)
-                        end_hour = start_hour + daily_hours
-                        next_day = end_hour >= 24
-                        if end_hour >= 24:
-                            end_hour -= 24
-                        horario = f"{int(start_hour):02d}:00-{int(end_hour):02d}:00" + ("+1" if next_day else "")
+                        # Para PT usar las horas reales trabajadas según el patrón
+                        start_idx = int(start_hour)
+                        end_idx = (int(work_hours[-1]) + 1) % 24
+                        next_day = end_idx <= start_idx
+                        horario = f"{start_idx:02d}:00-{end_idx:02d}:00" + ("+1" if next_day else "")
                     else:
                         # Otros turnos normales
                         end_hour = int(start_hour + total_hours)

--- a/manual_check.py
+++ b/manual_check.py
@@ -1,0 +1,9 @@
+import numpy as np
+
+# Simulate work hours for a PT shift starting at 22:00 lasting 6h
+work_hours = np.array([22, 23, 0, 1, 2, 3])
+start_idx = 22
+end_idx = (int(work_hours[-1]) + 1) % 24
+next_day = end_idx <= start_idx
+horario = f"{start_idx:02d}:00-{end_idx:02d}:00" + ("+1" if next_day else "")
+print(horario)


### PR DESCRIPTION
## Summary
- adjust PT shift end time calculation to use modulo and detect next-day wrap
- add manual check script demonstrating a 22:00-04:00 shift

## Testing
- `python manual_check.py`


------
https://chatgpt.com/codex/tasks/task_e_68793ed3becc8327aea3812170b61e4a