### PR TITLE
Add JEAN optimization profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
-# schedules
+# Schedules Generator
+
+This project creates optimized work schedules using Streamlit.
+
+## Perfil JEAN
+
+Incluye un perfil de optimización llamado **JEAN** pensado para obtener
+una cobertura real cercana al 100% con la menor cantidad de agentes
+posible, reduciendo el exceso de personal.

--- a/generador_turnos_2025_cnx_BACKUP_F_FIRST_P_LAST (1).py
+++ b/generador_turnos_2025_cnx_BACKUP_F_FIRST_P_LAST (1).py
@@ -299,6 +299,7 @@ optimization_profile = st.sidebar.selectbox(
         "100% Cobertura Total",
         "Cobertura Perfecta",
         "100% Exacto",
+        "JEAN",
         "Personalizado",
         "Aprendizaje Adaptativo"
     ],
@@ -352,6 +353,7 @@ else:
         "100% Cobertura Total": {"agent_limit_factor": 5, "excess_penalty": 0.001, "peak_bonus": 4.0, "critical_bonus": 5.0},
         "Cobertura Perfecta": {"agent_limit_factor": 8, "excess_penalty": 0.01, "peak_bonus": 3.0, "critical_bonus": 4.0},
         "100% Exacto": {"agent_limit_factor": 6, "excess_penalty": 0.005, "peak_bonus": 4.0, "critical_bonus": 5.0},
+        "JEAN": {"agent_limit_factor": 20, "excess_penalty": 1.5, "peak_bonus": 2.0, "critical_bonus": 2.5},
         "Aprendizaje Adaptativo": {"agent_limit_factor": 8, "excess_penalty": 0.01, "peak_bonus": 3.0, "critical_bonus": 4.0}
     }
     


### PR DESCRIPTION
## Summary
- add new `JEAN` optimization profile to reduce excess staffing
- mention the new profile in README

## Testing
- `python -m py_compile 'generador_turnos_2025_cnx_BACKUP_F_FIRST_P_LAST (1).py'`

------
https://chatgpt.com/codex/tasks/task_e_68796bcf81f08327963f0711b2cd100c