### PR TITLE
Fix package name casing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ pyworkforce
 ortools
 matplotlib
 seaborn
-PULP
+pulp


### PR DESCRIPTION
## Summary
- fix `pulp` package name casing in requirements

## Testing
- `python -m pip install -r requirements.txt`
- `python manual_check.py`


------
https://chatgpt.com/codex/tasks/task_e_68796ff3a82083279163352db57c1519