### PR TITLE
Refine JEAN profile to avoid overstaffing

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,4 +30,5 @@ The expected Excel file `Requerido.xlsx` must contain a column named `Día` with
 
 Incluye un perfil de optimización llamado **JEAN** pensado para obtener
 una cobertura real cercana al 100% con la menor cantidad de agentes
-posible, reduciendo el exceso de personal.
+posible. Este perfil ahora aplica una penalización de exceso más fuerte
+para asegurar que la cobertura real y pura se mantengan en 100%.

--- a/generador_turnos_2025_cnx_BACKUP_F_FIRST_P_LAST (1).py
+++ b/generador_turnos_2025_cnx_BACKUP_F_FIRST_P_LAST (1).py
@@ -353,7 +353,7 @@ else:
         "100% Cobertura Total": {"agent_limit_factor": 5, "excess_penalty": 0.001, "peak_bonus": 4.0, "critical_bonus": 5.0},
         "Cobertura Perfecta": {"agent_limit_factor": 8, "excess_penalty": 0.01, "peak_bonus": 3.0, "critical_bonus": 4.0},
         "100% Exacto": {"agent_limit_factor": 6, "excess_penalty": 0.005, "peak_bonus": 4.0, "critical_bonus": 5.0},
-        "JEAN": {"agent_limit_factor": 30, "excess_penalty": 2.5, "peak_bonus": 2.0, "critical_bonus": 2.5},
+        "JEAN": {"agent_limit_factor": 30, "excess_penalty": 5.0, "peak_bonus": 2.0, "critical_bonus": 2.5},
         "Aprendizaje Adaptativo": {"agent_limit_factor": 8, "excess_penalty": 0.01, "peak_bonus": 3.0, "critical_bonus": 4.0}
     }
     
@@ -1375,7 +1375,11 @@ def optimize_pt_complete(pt_shifts, remaining_demand):
     total_excess = pulp.lpSum([excess_vars[(day, hour)] for day in range(7) for hour in range(24)])
     total_pt_agents = pulp.lpSum([pt_vars[shift] for shift in pt_shifts.keys()])
     
-    prob += total_deficit * 1000 + total_excess * 10 + total_pt_agents * 1
+    prob += total_deficit * 1000 + total_excess * (excess_penalty * 20) + total_pt_agents * 1
+
+    # Para el perfil JEAN no se permite ningún exceso
+    if optimization_profile == "JEAN":
+        prob += total_excess == 0
     
     # Restricciones de cobertura
     for day in range(7):


### PR DESCRIPTION
## Summary
- bump JEAN `excess_penalty` to 5.0
- disallow overstaffing in `optimize_pt_complete` and respect profile penalty
- document the stronger penalty in README

## Testing
- `python -m py_compile "generador_turnos_2025_cnx_BACKUP_F_FIRST_P_LAST (1).py" manual_check.py`

------
https://chatgpt.com/codex/tasks/task_e_68797d66d9e48327a1e54ebbee22c2f9