### PR TITLE
Support FT/PT sliders for JEAN Personalizado

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,4 +36,7 @@ déficit siempre que la cobertura alcance el objetivo (al menos 98 %).
 
 ## Perfil JEAN Personalizado
 
-Este modo solo permite elegir los días laborables por semana, la duración diaria del turno y la ventana de break. El resto de parámetros del solver se fijan automáticamente según el perfil **JEAN**.
+Permite configurar de forma independiente los turnos **Full Time** y **Part Time**.
+Puedes ajustar los días laborables, la duración de la jornada y la ventana de
+break para cada tipo. El resto de parámetros del solver se fijan automáticamente
+según el perfil **JEAN**.


### PR DESCRIPTION
## Summary
- add independent FT and PT sliders in JEAN Personalizado configuration
- generate FT and PT patterns separately based on those settings
- document new JEAN Personalizado behaviour

## Testing
- `python -m py_compile 'generador_turnos_2025_cnx_BACKUP_F_FIRST_P_LAST (1).py'`

------
https://chatgpt.com/codex/tasks/task_e_687a86be0b0483279911684ed347dc48