### PR TITLE
Allow zero PT break

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,4 +39,5 @@ déficit siempre que la cobertura alcance el objetivo (al menos 98 %).
 Permite configurar de forma independiente los turnos **Full Time** y **Part Time**.
 Puedes ajustar los días laborables, la duración de la jornada y la ventana de
 break para cada tipo. El resto de parámetros del solver se fijan automáticamente
-según el perfil **JEAN**.
+según el perfil **JEAN**. Para Part Time la duración del break puede fijarse en
+0 horas si así lo requiere la normativa.

--- a/generador_turnos_2025_cnx_BACKUP_F_FIRST_P_LAST (1).py
+++ b/generador_turnos_2025_cnx_BACKUP_F_FIRST_P_LAST (1).py
@@ -385,7 +385,9 @@ elif optimization_profile == "JEAN Personalizado":
     st.sidebar.markdown("**Part Time Configuration**")
     pt_work_days = st.sidebar.slider("Días laborables PT", 1, 7, 5)
     pt_shift_hours = st.sidebar.slider("Horas de turno PT", 4, 12, 6)
-    pt_break_duration = st.sidebar.slider("Duración del break PT (h)", 1, 3, 1)
+    pt_break_duration = st.sidebar.slider(
+        "Duración del break PT (h)", 0, 3, 1
+    )
     pt_break_from_start = st.sidebar.slider(
         "Break desde inicio PT (horas)",
         min_value=1.0,


### PR DESCRIPTION
## Summary
- make PT break duration slider allow 0 hours
- mention this capability in README

## Testing
- `python3 -m py_compile "generador_turnos_2025_cnx_BACKUP_F_FIRST_P_LAST (1).py"`
- `python3 -m py_compile manual_check.py`

------
https://chatgpt.com/codex/tasks/task_e_687a7e3e04448327b49d6bf812eba39c