### PR TITLE
Add JSON templates for JEAN personalizado

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,30 @@ Puedes ajustar los días laborables, la duración de la jornada y la ventana de
 break para cada tipo. El resto de parámetros del solver se fijan automáticamente
 según el perfil **JEAN**. Para Part Time la duración del break puede fijarse en
 0 horas si así lo requiere la normativa.
+
+## JSON Template
+
+The **JEAN Personalizado** sidebar allows loading a configuration template in
+JSON format. Upload a file through the *Plantilla JSON* control to pre-fill all
+shift parameters and hide the sliders.
+
+Example `shift_config_template.json`:
+
+```json
+{
+  "use_ft": true,
+  "use_pt": true,
+  "ft_work_days": 5,
+  "ft_shift_hours": 8,
+  "ft_break_duration": 1,
+  "ft_break_from_start": 2,
+  "ft_break_from_end": 2,
+  "pt_work_days": 5,
+  "pt_shift_hours": 6,
+  "pt_break_duration": 1,
+  "pt_break_from_start": 2,
+  "pt_break_from_end": 2
+}
+```
+
+Any missing field in the template defaults to the standard slider values.

--- a/generador_turnos_2025_cnx_BACKUP_F_FIRST_P_LAST (1).py
+++ b/generador_turnos_2025_cnx_BACKUP_F_FIRST_P_LAST (1).py
@@ -358,51 +358,81 @@ if optimization_profile == "Personalizado":
 
 elif optimization_profile == "JEAN Personalizado":
     st.sidebar.subheader("⚙️ JEAN Personalizado")
+    template_file = st.sidebar.file_uploader("Plantilla JSON")
     jean_cfg = profiles["JEAN"]
     agent_limit_factor = jean_cfg["agent_limit_factor"]
     excess_penalty = jean_cfg["excess_penalty"]
     peak_bonus = jean_cfg["peak_bonus"]
     critical_bonus = jean_cfg["critical_bonus"]
 
-    st.sidebar.markdown("**Full Time Configuration**")
-    ft_work_days = st.sidebar.slider("Días laborables FT", 1, 7, 5)
-    ft_shift_hours = st.sidebar.slider("Horas de turno FT", 4, 12, 8)
-    ft_break_duration = st.sidebar.slider("Duración del break FT (h)", 1, 3, 1)
-    ft_break_from_start = st.sidebar.slider(
-        "Break desde inicio FT (horas)",
-        min_value=1.0,
-        max_value=float(max(1, ft_shift_hours - 1)),
-        value=2.0,
-        step=0.5,
-    )
-    ft_break_from_end = st.sidebar.slider(
-        "Break antes del fin FT (horas)",
-        min_value=1.0,
-        max_value=float(max(1, ft_shift_hours - 1)),
-        value=2.0,
-        step=0.5,
-    )
+    if template_file:
+        try:
+            template_cfg = json.load(template_file)
+        except Exception as e:
+            st.sidebar.error(f"Error al leer plantilla: {e}")
+            template_cfg = {}
 
-    st.sidebar.markdown("**Part Time Configuration**")
-    pt_work_days = st.sidebar.slider("Días laborables PT", 1, 7, 5)
-    pt_shift_hours = st.sidebar.slider("Horas de turno PT", 4, 12, 6)
-    pt_break_duration = st.sidebar.slider(
-        "Duración del break PT (h)", 0, 3, 1
-    )
-    pt_break_from_start = st.sidebar.slider(
-        "Break desde inicio PT (horas)",
-        min_value=1.0,
-        max_value=float(max(1, pt_shift_hours - 1)),
-        value=2.0,
-        step=0.5,
-    )
-    pt_break_from_end = st.sidebar.slider(
-        "Break antes del fin PT (horas)",
-        min_value=1.0,
-        max_value=float(max(1, pt_shift_hours - 1)),
-        value=2.0,
-        step=0.5,
-    )
+        use_ft = st.sidebar.checkbox(
+            "Permitir FT", template_cfg.get("use_ft", True), key="jean_use_ft"
+        )
+        use_pt = st.sidebar.checkbox(
+            "Permitir PT", template_cfg.get("use_pt", True), key="jean_use_pt"
+        )
+
+        ft_work_days = template_cfg.get("ft_work_days", 5)
+        ft_shift_hours = template_cfg.get("ft_shift_hours", 8)
+        ft_break_duration = template_cfg.get("ft_break_duration", 1)
+        ft_break_from_start = template_cfg.get("ft_break_from_start", 2.0)
+        ft_break_from_end = template_cfg.get("ft_break_from_end", 2.0)
+
+        pt_work_days = template_cfg.get("pt_work_days", 5)
+        pt_shift_hours = template_cfg.get("pt_shift_hours", 6)
+        pt_break_duration = template_cfg.get("pt_break_duration", 1)
+        pt_break_from_start = template_cfg.get("pt_break_from_start", 2.0)
+        pt_break_from_end = template_cfg.get("pt_break_from_end", 2.0)
+    else:
+        use_ft = st.sidebar.checkbox("Permitir FT", True, key="jean_use_ft")
+        use_pt = st.sidebar.checkbox("Permitir PT", True, key="jean_use_pt")
+
+        st.sidebar.markdown("**Full Time Configuration**")
+        ft_work_days = st.sidebar.slider("Días laborables FT", 1, 7, 5)
+        ft_shift_hours = st.sidebar.slider("Horas de turno FT", 4, 12, 8)
+        ft_break_duration = st.sidebar.slider("Duración del break FT (h)", 1, 3, 1)
+        ft_break_from_start = st.sidebar.slider(
+            "Break desde inicio FT (horas)",
+            min_value=1.0,
+            max_value=float(max(1, ft_shift_hours - 1)),
+            value=2.0,
+            step=0.5,
+        )
+        ft_break_from_end = st.sidebar.slider(
+            "Break antes del fin FT (horas)",
+            min_value=1.0,
+            max_value=float(max(1, ft_shift_hours - 1)),
+            value=2.0,
+            step=0.5,
+        )
+
+        st.sidebar.markdown("**Part Time Configuration**")
+        pt_work_days = st.sidebar.slider("Días laborables PT", 1, 7, 5)
+        pt_shift_hours = st.sidebar.slider("Horas de turno PT", 4, 12, 6)
+        pt_break_duration = st.sidebar.slider(
+            "Duración del break PT (h)", 0, 3, 1
+        )
+        pt_break_from_start = st.sidebar.slider(
+            "Break desde inicio PT (horas)",
+            min_value=1.0,
+            max_value=float(max(1, pt_shift_hours - 1)),
+            value=2.0,
+            step=0.5,
+        )
+        pt_break_from_end = st.sidebar.slider(
+            "Break antes del fin PT (horas)",
+            min_value=1.0,
+            max_value=float(max(1, pt_shift_hours - 1)),
+            value=2.0,
+            step=0.5,
+        )
 
 else:
     # Configuraciones predefinidas

--- a/shift_config_template.json
+++ b/shift_config_template.json
@@ -1,0 +1,14 @@
+{
+  "use_ft": true,
+  "use_pt": true,
+  "ft_work_days": 5,
+  "ft_shift_hours": 8,
+  "ft_break_duration": 1,
+  "ft_break_from_start": 2,
+  "ft_break_from_end": 2,
+  "pt_work_days": 5,
+  "pt_shift_hours": 6,
+  "pt_break_duration": 1,
+  "pt_break_from_start": 2,
+  "pt_break_from_end": 2
+}


### PR DESCRIPTION
## Summary
- add JSON template support for the JEAN Personalizado profile
- document template format in README
- provide sample `shift_config_template.json`

## Testing
- `python -m py_compile 'generador_turnos_2025_cnx_BACKUP_F_FIRST_P_LAST (1).py'`

------
https://chatgpt.com/codex/tasks/task_e_687a9e9d136c832798d31fb83cde303f