### PR TITLE
Add new shift loader format and update app

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,35 @@ Example `examples/shift_config.json`:
   ]
 }
 ```
+
+The loader also understands a **v2** format where each shift specifies the
+resolution of the start times, the number of segments per duration and a break
+window. Upload a file following this structure when using **JEAN Personalizado**
+to predefine the available patterns.
+
+Example `examples/shift_config_v2.json`:
+
+```json
+{
+  "shifts": [
+    {
+      "name": "FT_12_9_6",
+      "slot_duration_minutes": 30,
+      "pattern": {
+        "work_days": 6,
+        "segments": [
+          {"hours": 12, "count": 2},
+          {"hours": 9,  "count": 2},
+          {"hours": 6,  "count": 2}
+        ]
+      },
+      "break": {
+        "enabled": true,
+        "length_minutes": 60,
+        "earliest_after_start": 120,
+        "latest_before_end": 120
+      }
+    }
+  ]
+}
+```

--- a/examples/shift_config_v2.json
+++ b/examples/shift_config_v2.json
@@ -1,0 +1,22 @@
+{
+  "shifts": [
+    {
+      "name": "FT_12_9_6",
+      "slot_duration_minutes": 30,
+      "pattern": {
+        "work_days": 6,
+        "segments": [
+          {"hours": 12, "count": 2},
+          {"hours": 9, "count": 2},
+          {"hours": 6, "count": 2}
+        ]
+      },
+      "break": {
+        "enabled": true,
+        "length_minutes": 60,
+        "earliest_after_start": 120,
+        "latest_before_end": 120
+      }
+    }
+  ]
+}

--- a/generador_turnos_2025_cnx_BACKUP_F_FIRST_P_LAST (1).py
+++ b/generador_turnos_2025_cnx_BACKUP_F_FIRST_P_LAST (1).py
@@ -663,14 +663,12 @@ def generate_shifts_coverage_corrected():
     total_patterns = 0
     current_patterns = 0
     
-    # Horarios de inicio optimizados (menos opciones para reducir complejidad)
-    # Expandir horarios de inicio para más patrones
-    start_hours = []
-    for h in range(0, 24):  # Todas las horas del día
-        start_hours.append(h)
-        start_hours.append(h + 0.5)  # Medios horarios
+    # Horarios de inicio optimizados
+    step = 0.5
+    if optimization_profile == "JEAN Personalizado":
+        step = template_cfg.get("slot_duration_minutes", 30) / 60
 
-    start_hours = [h for h in start_hours if 0 <= h <= 23.5]
+    start_hours = [h for h in np.arange(0, 24, step) if h <= 23.5]
 
     # Perfil JEAN Personalizado: leer patrones desde JSON y retornar
     if optimization_profile == "JEAN Personalizado":
@@ -680,6 +678,7 @@ def generate_shifts_coverage_corrected():
             start_hours=start_hours,
             break_from_start=break_from_start,
             break_from_end=break_from_end,
+            slot_duration_minutes=int(step * 60),
         )
 
         if not use_ft:

--- a/tests/test_json_shift_loader.py
+++ b/tests/test_json_shift_loader.py
@@ -1,0 +1,19 @@
+import unittest
+import numpy as np
+from json_shift_loader import load_shift_patterns
+
+class LoaderTest(unittest.TestCase):
+    def test_v1_format(self):
+        data = load_shift_patterns('examples/shift_config.json')
+        self.assertTrue(data)
+        for arr in data.values():
+            self.assertEqual(arr.shape, (7*24,))
+
+    def test_v2_format(self):
+        data = load_shift_patterns('examples/shift_config_v2.json')
+        self.assertTrue(data)
+        for arr in data.values():
+            self.assertEqual(arr.shape, (7*24,))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- extend `load_shift_patterns` to support slot duration, segment counts and break options
- allow JEAN Personalizado to read `slot_duration_minutes`
- document new JSON format
- add example config and regression tests

## Testing
- `python -m unittest tests/test_json_shift_loader.py`

------
https://chatgpt.com/codex/tasks/task_e_687ad496706c8327a4109d6fdd6f1380