### PR TITLE
Remove redundant global statement

### DIFF
--- a/generador_turnos_2025_cnx_BACKUP_F_FIRST_P_LAST (1).py
+++ b/generador_turnos_2025_cnx_BACKUP_F_FIRST_P_LAST (1).py
@@ -672,7 +672,6 @@ def generate_shifts_coverage_corrected():
 
     # Perfil JEAN Personalizado: leer patrones desde JSON y retornar
     if optimization_profile == "JEAN Personalizado":
-        global template_cfg
         shifts_coverage = load_shift_patterns(
             template_cfg,
             start_hours=start_hours,


### PR DESCRIPTION
## Summary
- eliminate `global template_cfg` in `generate_shifts_coverage_corrected`
- keep using `template_cfg` to load patterns

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ad9b8b978832794f7ebd565541bb2