### PR TITLE
Reduce memory usage when generating patterns

### DIFF
--- a/generador_turnos_2025_cnx_BACKUP_F_FIRST_P_LAST (1).py
+++ b/generador_turnos_2025_cnx_BACKUP_F_FIRST_P_LAST (1).py
@@ -1974,7 +1974,7 @@ def evaluate_solution_quality(coverage_matrix, demand_matrix):
 
 def generate_weekly_pattern(start_hour, duration, working_days, dso_day=None, break_len=1):
     """Genera patrón semanal con breaks inteligentes"""
-    pattern = np.zeros((7, 24))
+    pattern = np.zeros((7, 24), dtype=np.int8)
     
     for day in working_days:
         if day != dso_day:  # Excluir día de descanso
@@ -2071,7 +2071,7 @@ def get_valid_break_times(start_hour, duration):
 
 def generate_weekly_pattern_with_break(start_hour, duration, working_days, dso_day, break_start, break_len=1):
     """Genera patrón semanal con break específico - CORREGIDO para turnos que cruzan medianoche"""
-    pattern = np.zeros((7, 24))
+    pattern = np.zeros((7, 24), dtype=np.int8)
     
     for day in working_days:
         if day == dso_day:
@@ -2102,7 +2102,7 @@ def generate_weekly_pattern_with_break(start_hour, duration, working_days, dso_d
 
 def generate_weekly_pattern_simple(start_hour, duration, working_days):
     """Genera patrón semanal simple sin break (para PT)"""
-    pattern = np.zeros((7, 24))
+    pattern = np.zeros((7, 24), dtype=np.int8)
     
     for day in working_days:
         for h in range(duration):
@@ -2114,7 +2114,7 @@ def generate_weekly_pattern_simple(start_hour, duration, working_days):
 
 def generate_weekly_pattern_pt5(start_hour, working_days):
     """Genera patrón de 24h para PT5 (5h en cuatro días y 4h en uno)"""
-    pattern = np.zeros((7, 24))
+    pattern = np.zeros((7, 24), dtype=np.int8)
 
     if not working_days:
         return pattern.flatten()
@@ -2131,7 +2131,7 @@ def generate_weekly_pattern_pt5(start_hour, working_days):
 
 def generate_weekly_pattern_10h8(start_hour, working_days, eight_hour_day, break_len=1):
     """Genera patrón con cuatro días de 10h y uno de 8h"""
-    pattern = np.zeros((7, 24))
+    pattern = np.zeros((7, 24), dtype=np.int8)
 
     for day in working_days:
         duration = 8 if day == eight_hour_day else 10
@@ -2157,7 +2157,7 @@ def generate_weekly_pattern_10h8(start_hour, working_days, eight_hour_day, break
 
 def generate_weekly_pattern_advanced(start_hour, duration, working_days, break_position):
     """Genera patrón semanal avanzado con break posicionado dinámicamente"""
-    pattern = np.zeros((7, 24))
+    pattern = np.zeros((7, 24), dtype=np.int8)
     
     for day in working_days:
         # Marcar horas de trabajo

--- a/json_shift_loader.py
+++ b/json_shift_loader.py
@@ -7,7 +7,7 @@ from typing import Dict, List, Iterable, Union
 def _build_pattern(days: Iterable[int], durations: Iterable[int], start_hour: float,
                    break_len: float, break_from_start: float, break_from_end: float) -> np.ndarray:
     """Return flattened 7x24 matrix for given days/durations."""
-    pattern = np.zeros((7, 24))
+    pattern = np.zeros((7, 24), dtype=np.int8)
     for day, dur in zip(days, durations):
         for h in range(int(dur)):
             idx = int(start_hour + h) % 24


### PR DESCRIPTION
## Summary
- reduce array dtype size to int8 in `json_shift_loader`
- apply the same dtype change in pattern generation helpers

## Testing
- `pip install -q -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b0d4133bc8327abc1d267275e471d