### PR TITLE
Ensure unique coverage patterns

### DIFF
--- a/generador_turnos_2025_cnx_BACKUP_F_FIRST_P_LAST (1).py
+++ b/generador_turnos_2025_cnx_BACKUP_F_FIRST_P_LAST (1).py
@@ -60,6 +60,7 @@ def load_shift_patterns(
         data = cfg
 
     shifts_coverage: Dict[str, np.ndarray] = {}
+    unique_patterns: Dict[bytes, str] = {}
     for shift in data.get("shifts", []):
         name = shift.get("name", "SHIFT")
         pat = shift.get("pattern", {})
@@ -112,10 +113,14 @@ def load_shift_patterns(
                     pattern = _build_pattern(
                         days_sel, perm, sh, brk_len, brk_start, brk_end
                     )
+                    pat_key = pattern.tobytes()
+                    if pat_key in unique_patterns:
+                        continue
                     day_str = "".join(map(str, days_sel))
                     seg_str = "_".join(map(str, perm))
                     shift_name = f"{name}_{sh:04.1f}_{day_str}_{seg_str}"
                     shifts_coverage[shift_name] = pattern
+                    unique_patterns[pat_key] = shift_name
 
     return shifts_coverage
 try:

--- a/tests/test_json_shift_loader.py
+++ b/tests/test_json_shift_loader.py
@@ -41,5 +41,8 @@ class LoaderTest(unittest.TestCase):
         for arr in data.values():
             self.assertEqual(arr.shape, (7*24,))
 
+        # ensure patterns are deduplicated
+        self.assertEqual(len(data), 15120)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- deduplicate generated shift patterns in `load_shift_patterns`
- assert expected unique patterns for v2 config

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b18b7ad588327ae90a907d874de46