### PR TITLE
Validate slot duration in JSON loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ Example `examples/shift_config.json`:
 The loader also understands a **v2** format where each shift specifies the
 resolution of the start times, the number of segments per duration and a break
 window. Upload a file following this structure when using **JEAN Personalizado**
-to predefine the available patterns.
+to predefine the available patterns. Only a slot duration of 60 minutes is
+currently supported; files using a different value will be rejected.
 
 Example `examples/shift_config_v2.json`:
 
@@ -99,7 +100,7 @@ Example `examples/shift_config_v2.json`:
   "shifts": [
     {
       "name": "FT_12_9_6",
-      "slot_duration_minutes": 30,
+      "slot_duration_minutes": 60,
       "pattern": {
         "work_days": 6,
         "segments": [

--- a/examples/shift_config_jean_v2.json
+++ b/examples/shift_config_jean_v2.json
@@ -14,7 +14,7 @@
   "shifts": [
     {
       "name": "FT_12_9_6",
-      "slot_duration_minutes": 30,
+      "slot_duration_minutes": 60,
       "pattern": {
         "work_days": 6,
         "segments": [

--- a/examples/shift_config_v2.json
+++ b/examples/shift_config_v2.json
@@ -2,7 +2,7 @@
   "shifts": [
     {
       "name": "FT_12_9_6",
-      "slot_duration_minutes": 30,
+      "slot_duration_minutes": 60,
       "pattern": {
         "work_days": 6,
         "segments": [

--- a/generador_turnos_2025_cnx_BACKUP_F_FIRST_P_LAST (1).py
+++ b/generador_turnos_2025_cnx_BACKUP_F_FIRST_P_LAST (1).py
@@ -50,7 +50,7 @@ def load_shift_patterns(
     start_hours: Iterable[float] | None = None,
     break_from_start: float = 2.0,
     break_from_end: float = 2.0,
-    slot_duration_minutes: int = 30,
+    slot_duration_minutes: int = 60,
 ) -> Dict[str, np.ndarray]:
     """Parse JSON shift configuration and return pattern dictionary."""
     if isinstance(cfg, str):
@@ -66,6 +66,8 @@ def load_shift_patterns(
         brk = shift.get("break", 0)
 
         slot_min = shift.get("slot_duration_minutes", slot_duration_minutes)
+        if slot_min != 60:
+            raise ValueError("Only slot_duration_minutes=60 is currently supported")
         step = slot_min / 60
         sh_hours = (
             list(start_hours)
@@ -767,9 +769,9 @@ def generate_shifts_coverage_corrected():
     current_patterns = 0
     
     # Horarios de inicio optimizados
-    step = 0.5
+    step = 1.0
     if optimization_profile == "JEAN Personalizado":
-        step = template_cfg.get("slot_duration_minutes", 30) / 60
+        step = template_cfg.get("slot_duration_minutes", 60) / 60
 
     start_hours = [h for h in np.arange(0, 24, step) if h <= 23.5]
 

--- a/tests/test_json_shift_loader.py
+++ b/tests/test_json_shift_loader.py
@@ -4,6 +4,7 @@ import importlib.util
 from pathlib import Path
 from types import ModuleType
 import sys
+import json
 
 for name in ["streamlit", "seaborn", "pandas"]:
     sys.modules.setdefault(name, ModuleType(name))
@@ -40,6 +41,13 @@ class LoaderTest(unittest.TestCase):
         self.assertTrue(data)
         for arr in data.values():
             self.assertEqual(arr.shape, (7*24,))
+
+    def test_invalid_slot_duration(self):
+        with open('examples/shift_config_v2.json') as fh:
+            cfg = json.load(fh)
+        cfg['shifts'][0]['slot_duration_minutes'] = 30
+        with self.assertRaises(ValueError):
+            load_shift_patterns(cfg)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- reject unsupported slot_duration_minutes values
- default to 60-minute slots
- update JSON examples and README to mention limitation
- test validation behaviour

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b18b7784483279aff6a5e2d0c92bd