### PR TITLE
Support variable slot duration in shift patterns

### DIFF
--- a/tests/test_json_shift_loader.py
+++ b/tests/test_json_shift_loader.py
@@ -30,19 +30,19 @@ load_shift_patterns = module.load_shift_patterns
 
 class LoaderTest(unittest.TestCase):
     def test_v1_format(self):
-        data = load_shift_patterns('examples/shift_config.json')
+        data = load_shift_patterns('examples/shift_config.json', slot_duration_minutes=60)
         self.assertTrue(data)
         for arr in data.values():
-            self.assertEqual(arr.shape, (7*24,))
+            self.assertEqual(arr.shape, (7 * 24,))
 
     def test_v2_format(self):
-        data = load_shift_patterns('examples/shift_config_v2.json')
+        data = load_shift_patterns('examples/shift_config_v2.json', slot_duration_minutes=30)
         self.assertTrue(data)
         for arr in data.values():
-            self.assertEqual(arr.shape, (7*24,))
+            self.assertEqual(arr.shape, (7 * 48,))
 
         # ensure patterns are deduplicated
-        self.assertEqual(len(data), 15120)
+        self.assertEqual(len(data), 30240)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- add `slot_factor` parameter to `_build_pattern` for custom resolutions
- validate slot size and pass it through `load_shift_patterns`
- update optimization logic and reshape operations to use dynamic slot counts
- adjust unit tests for sub-hour slot sizes

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b1b8799d08327aa885d8c95ff3a1b