### PR TITLE
Document single-hour slot resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The expected Excel file `Requerido.xlsx` must contain a column named `Día` with
 
 ## Time Slot Resolution
 
-Schedules are represented using 7×24 matrices. **Each slot corresponds to one hour**, so both demand and generated patterns operate at hourly resolution. The example JSON files therefore use `"slot_duration_minutes": 60`.
+Schedules are represented using 7×24 matrices. **Each slot corresponds to one hour** and the current implementation cannot subdivide these hours. Values such as `"slot_duration_minutes": 30` are ignored unless you use an enhanced version of the generator. The bundled examples therefore keep `"slot_duration_minutes": 60` and all demand and pattern data operate at hourly resolution.
 
 With hourly slots the JEAN profile can produce over a thousand possible patterns when all shift types are enabled (around 1360 for a full seven‑day demand).
 Coverage calculations now use compact integer arrays to keep memory usage low during optimization.
@@ -106,7 +106,7 @@ Example `examples/shift_config_v2.json`:
   "shifts": [
     {
       "name": "FT_12_9_6",
-      "slot_duration_minutes": 30,
+      "slot_duration_minutes": 60,
       "pattern": {
         "work_days": 6,
         "segments": [

--- a/examples/shift_config_jean_v2.json
+++ b/examples/shift_config_jean_v2.json
@@ -14,7 +14,7 @@
   "shifts": [
     {
       "name": "FT_12_9_6",
-      "slot_duration_minutes": 30,
+      "slot_duration_minutes": 60,
       "pattern": {
         "work_days": 6,
         "segments": [

--- a/examples/shift_config_v2.json
+++ b/examples/shift_config_v2.json
@@ -2,7 +2,7 @@
   "shifts": [
     {
       "name": "FT_12_9_6",
-      "slot_duration_minutes": 30,
+      "slot_duration_minutes": 60,
       "pattern": {
         "work_days": 6,
         "segments": [


### PR DESCRIPTION
## Summary
- clarify that the scheduler works only with 60 minute slots
- update v2 example files to use `slot_duration_minutes: 60`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b1b8964f48327954100551206213b