### PR TITLE
Add max_patterns limit for shift pattern generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,13 @@ A single file may also combine the JEAN slider parameters with the
 `shifts` array in **v2** format. See `examples/shift_config_jean_v2.json`
 for a complete example.
 
+## Limiting Generated Patterns
+
+Both `load_shift_patterns()` and the internal `generate_shifts_coverage_corrected()`
+function accept an optional `max_patterns` argument. When provided, pattern
+generation stops once this limit is reached which is useful during testing
+or when exploring large configuration spaces.
+
 ## Testing
 
 After installing the dependencies, run the test suite with:

--- a/tests/test_json_shift_loader.py
+++ b/tests/test_json_shift_loader.py
@@ -44,5 +44,9 @@ class LoaderTest(unittest.TestCase):
         # ensure patterns are deduplicated
         self.assertEqual(len(data), 30240)
 
+    def test_max_patterns_limit(self):
+        data = load_shift_patterns('examples/shift_config_v2.json', slot_duration_minutes=30, max_patterns=10)
+        self.assertEqual(len(data), 10)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- support optional `max_patterns` limit in `load_shift_patterns`
- propagate the limit to pattern generation and show truncated count
- document the option in README
- add unit test for the new parameter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bc1047358832796a719d9ea1f8adf