### PR TITLE
Enforce hourly slot resolution

### DIFF
--- a/generador_turnos_2025_cnx_BACKUP_F_FIRST_P_LAST (1).py
+++ b/generador_turnos_2025_cnx_BACKUP_F_FIRST_P_LAST (1).py
@@ -66,8 +66,11 @@ def load_shift_patterns(
     else:
         data = cfg
 
-    if slot_duration_minutes is not None and 60 % slot_duration_minutes != 0:
-        raise ValueError("slot_duration_minutes must divide 60")
+    if slot_duration_minutes is not None:
+        if slot_duration_minutes != 60:
+            raise NotImplementedError("only 60-minute slots are supported")
+        if 60 % slot_duration_minutes != 0:
+            raise ValueError("slot_duration_minutes must divide 60")
 
     shifts_coverage: Dict[str, np.ndarray] = {}
     unique_patterns: Dict[bytes, str] = {}
@@ -81,6 +84,8 @@ def load_shift_patterns(
             if slot_duration_minutes is not None
             else shift.get("slot_duration_minutes", 60)
         )
+        if slot_min != 60:
+            raise NotImplementedError("only 60-minute slots are supported")
         if 60 % slot_min != 0:
             raise ValueError("slot_duration_minutes must divide 60")
         step = slot_min / 60

--- a/tests/test_json_shift_loader.py
+++ b/tests/test_json_shift_loader.py
@@ -36,13 +36,8 @@ class LoaderTest(unittest.TestCase):
             self.assertEqual(arr.shape, (7 * 24,))
 
     def test_v2_format(self):
-        data = load_shift_patterns('examples/shift_config_v2.json', slot_duration_minutes=30)
-        self.assertTrue(data)
-        for arr in data.values():
-            self.assertEqual(arr.shape, (7 * 48,))
-
-        # ensure patterns are deduplicated
-        self.assertEqual(len(data), 30240)
+        with self.assertRaises(NotImplementedError):
+            load_shift_patterns('examples/shift_config_v2.json', slot_duration_minutes=30)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- disallow shift resolutions other than 60 minutes
- update loader tests to expect NotImplementedError for unsupported resolutions

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bc104acdc8327814d2672f94e6104