### PR TITLE
Document fractional slot durations

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The expected Excel file `Requerido.xlsx` must contain a column named `Día` with
 
 ## Time Slot Resolution
 
-Schedules are represented using 7×24 matrices. **Each slot corresponds to one hour** and this is the only resolution supported by the optimizer. If a different `slot_duration_minutes` value is supplied in the JSON configuration the loader now raises a `ValueError`. The bundled examples therefore keep `"slot_duration_minutes": 60` and all demand and pattern data operate at hourly resolution.
+Schedules are represented using 7×24 matrices. **Each slot corresponds to one hour** and this remains the resolution used by the optimizer.  However `load_shift_patterns()` can parse configurations with smaller slots as long as the value divides 60 (for example 30 or 15 minutes).  When the optional `slot_duration_minutes` argument is supplied it overrides any per‑shift setting.  The examples show both hourly and 30‑minute resolutions.
 
 With hourly slots the JEAN profile can produce over a thousand possible patterns when all shift types are enabled (around 1360 for a full seven‑day demand).
 Coverage calculations now use compact integer arrays to keep memory usage low during optimization.
@@ -106,7 +106,7 @@ Example `examples/shift_config_v2.json`:
   "shifts": [
     {
       "name": "FT_12_9_6",
-      "slot_duration_minutes": 60,
+      "slot_duration_minutes": 30,
       "pattern": {
         "work_days": 6,
         "segments": [

--- a/examples/shift_config_jean_v2.json
+++ b/examples/shift_config_jean_v2.json
@@ -14,7 +14,7 @@
   "shifts": [
     {
       "name": "FT_12_9_6",
-      "slot_duration_minutes": 60,
+      "slot_duration_minutes": 30,
       "pattern": {
         "work_days": 6,
         "segments": [

--- a/examples/shift_config_v2.json
+++ b/examples/shift_config_v2.json
@@ -2,7 +2,7 @@
   "shifts": [
     {
       "name": "FT_12_9_6",
-      "slot_duration_minutes": 60,
+      "slot_duration_minutes": 30,
       "pattern": {
         "work_days": 6,
         "segments": [

--- a/generador_turnos_2025_cnx_BACKUP_F_FIRST_P_LAST (1).py
+++ b/generador_turnos_2025_cnx_BACKUP_F_FIRST_P_LAST (1).py
@@ -69,8 +69,6 @@ def load_shift_patterns(
         data = cfg
 
     if slot_duration_minutes is not None:
-        if slot_duration_minutes != 60:
-            raise NotImplementedError("only 60-minute slots are supported")
         if 60 % slot_duration_minutes != 0:
             raise ValueError("slot_duration_minutes must divide 60")
 
@@ -86,8 +84,6 @@ def load_shift_patterns(
             if slot_duration_minutes is not None
             else shift.get("slot_duration_minutes", 60)
         )
-        if slot_min != 60:
-            raise NotImplementedError("only 60-minute slots are supported")
         if 60 % slot_min != 0:
             raise ValueError("slot_duration_minutes must divide 60")
         step = slot_min / 60

--- a/tests/test_json_shift_loader.py
+++ b/tests/test_json_shift_loader.py
@@ -36,8 +36,10 @@ class LoaderTest(unittest.TestCase):
             self.assertEqual(arr.shape, (7 * 24,))
 
     def test_v2_format(self):
-        with self.assertRaises(NotImplementedError):
-            load_shift_patterns('examples/shift_config_v2.json', slot_duration_minutes=30)
+        data = load_shift_patterns('examples/shift_config_v2.json', slot_duration_minutes=30)
+        self.assertTrue(data)
+        for arr in data.values():
+            self.assertEqual(arr.shape, (7 * 48,))
 
     def test_max_patterns_limit(self):
         data = load_shift_patterns('examples/shift_config_v2.json', slot_duration_minutes=30, max_patterns=10)


### PR DESCRIPTION
## Summary
- clarify time slot resolution documentation
- document and support slot durations that divide 60
- update examples to use 30-minute slots
- adjust tests for fractional slots

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bc9bc3b0483278711d6a609a13a25