### PR TITLE
Validate slot duration limits

### DIFF
--- a/generador_turnos_2025_cnx_BACKUP_F_FIRST_P_LAST (1).py
+++ b/generador_turnos_2025_cnx_BACKUP_F_FIRST_P_LAST (1).py
@@ -69,6 +69,8 @@ def load_shift_patterns(
         data = cfg
 
     if slot_duration_minutes is not None:
+        if not 1 <= slot_duration_minutes <= 60:
+            raise ValueError("slot_duration_minutes must be between 1 and 60")
         if slot_duration_minutes != 60:
             raise NotImplementedError("only 60-minute slots are supported")
         if 60 % slot_duration_minutes != 0:
@@ -86,6 +88,8 @@ def load_shift_patterns(
             if slot_duration_minutes is not None
             else shift.get("slot_duration_minutes", 60)
         )
+        if not 1 <= slot_min <= 60:
+            raise ValueError("slot_duration_minutes must be between 1 and 60")
         if slot_min != 60:
             raise NotImplementedError("only 60-minute slots are supported")
         if 60 % slot_min != 0:

--- a/tests/test_json_shift_loader.py
+++ b/tests/test_json_shift_loader.py
@@ -40,8 +40,26 @@ class LoaderTest(unittest.TestCase):
             load_shift_patterns('examples/shift_config_v2.json', slot_duration_minutes=30)
 
     def test_max_patterns_limit(self):
-        data = load_shift_patterns('examples/shift_config_v2.json', slot_duration_minutes=30, max_patterns=10)
+        data = load_shift_patterns('examples/shift_config_v2.json', slot_duration_minutes=60, max_patterns=10)
         self.assertEqual(len(data), 10)
+
+    def test_slot_duration_range_param(self):
+        with self.assertRaises(ValueError):
+            load_shift_patterns('examples/shift_config.json', slot_duration_minutes=0)
+
+    def test_slot_duration_range_shift(self):
+        cfg = {
+            "shifts": [
+                {
+                    "name": "BAD",
+                    "slot_duration_minutes": 120,
+                    "pattern": {"work_days": [0], "segments": [8]},
+                    "break": 0,
+                }
+            ]
+        }
+        with self.assertRaises(ValueError):
+            load_shift_patterns(cfg, slot_duration_minutes=None)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- validate the `slot_duration_minutes` argument is in the range 1..60
- apply the same range check to per-shift slot durations
- update tests with new validations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bc9bc73808327a31be81095c37589