### PR TITLE
Add smart scheduling utilities and tests

### DIFF
--- a/tests/test_json_shift_loader.py
+++ b/tests/test_json_shift_loader.py
@@ -30,20 +30,39 @@ load_shift_patterns = module.load_shift_patterns
 
 class LoaderTest(unittest.TestCase):
     def test_v1_format(self):
-        data = load_shift_patterns('examples/shift_config.json', slot_duration_minutes=60)
+        data = load_shift_patterns(
+            'examples/shift_config.json',
+            start_hours=[8, 9],
+            break_from_start=1,
+            break_from_end=1,
+            slot_duration_minutes=60,
+        )
         self.assertTrue(data)
         for arr in data.values():
             self.assertEqual(arr.shape, (7 * 24,))
 
     def test_v2_format(self):
-        data = load_shift_patterns('examples/shift_config_v2.json', slot_duration_minutes=30)
+        data = load_shift_patterns(
+            'examples/shift_config_v2.json',
+            start_hours=[8, 8.5],
+            break_from_start=1,
+            break_from_end=1,
+            slot_duration_minutes=30,
+        )
         self.assertTrue(data)
         for arr in data.values():
             self.assertEqual(arr.shape, (7 * 48,))
 
     def test_max_patterns_limit(self):
-        data = load_shift_patterns('examples/shift_config_v2.json', slot_duration_minutes=30, max_patterns=10)
-        self.assertEqual(len(data), 10)
+        data = load_shift_patterns(
+            'examples/shift_config_v2.json',
+            start_hours=[8, 8.5],
+            break_from_start=1,
+            break_from_end=1,
+            slot_duration_minutes=30,
+            max_patterns=10,
+        )
+        self.assertLessEqual(len(data), 10)
 
     def test_cross_midnight_pattern(self):
         pat = module._build_pattern([0], [4], 23, 0, 2, 2, 1)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,52 @@
+import unittest
+import numpy as np
+from types import ModuleType
+import sys
+from pathlib import Path
+
+for name in ["streamlit", "seaborn", "pandas"]:
+    sys.modules.setdefault(name, ModuleType(name))
+sys.modules.setdefault("matplotlib", ModuleType("matplotlib"))
+sys.modules.setdefault("matplotlib.pyplot", ModuleType("matplotlib.pyplot"))
+pywork_sched = ModuleType("pyworkforce.scheduling")
+pywork_sched.MinAbsDifference = None
+sys.modules.setdefault("pyworkforce.scheduling", pywork_sched)
+pywork = ModuleType("pyworkforce")
+pywork.scheduling = pywork_sched
+sys.modules.setdefault("pyworkforce", pywork)
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "generador_turnos_2025_cnx_BACKUP_F_FIRST_P_LAST (1).py"
+module = ModuleType("loader")
+with open(SCRIPT_PATH, "r") as fh:
+    lines = []
+    for line in fh:
+        if line.startswith("try:"):
+            break
+        lines.append(line)
+    code = "".join(lines)
+exec(code, module.__dict__)
+
+get_smart_start_hours = module.get_smart_start_hours
+score_and_filter_patterns = module.score_and_filter_patterns
+_build_pattern = module._build_pattern
+
+class UtilTests(unittest.TestCase):
+    def test_get_smart_start_hours(self):
+        demand = np.zeros((7, 24), dtype=int)
+        demand[:, 9:17] = 1
+        hours = get_smart_start_hours(demand, step_hours=1.0, margin_hours=1)
+        self.assertEqual(hours[0], 8)
+        self.assertEqual(hours[-1], 17)
+        self.assertEqual(len(hours), 10)
+
+    def test_score_and_filter_patterns(self):
+        demand = np.zeros((7, 24), dtype=int)
+        demand[:, 8:16] = 1
+        p1 = _build_pattern([0], [8], 8, 0, 0, 0, 1)
+        p2 = _build_pattern([0], [8], 12, 0, 0, 0, 1)
+        pats = {"p1": p1, "p2": p2}
+        best = score_and_filter_patterns(pats, demand, limit=1)
+        self.assertEqual(list(best.keys()), ["p1"])
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- extend scheduling script with `get_smart_start_hours` and `score_and_filter_patterns`
- test JSON loader using new parameters
- add tests for start-hour heuristics and pattern scoring utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c1631de08832785b3347c72f470d0