### PR TITLE
Enhance schedule generator with memory monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,15 @@ in batches (2000 patterns by default), sorted by a quick heuristic score, so eve
 can be handled without exhausting RAM.  `generate_shifts_coverage_optimized()`
 still honours the `batch_size` option to emit patterns in smaller chunks.
 
+## Memory-aware Generation
+
+Several helper functions monitor memory usage during generation and
+optimization.  `monitor_memory_usage()` reports the current RAM usage,
+`adaptive_chunk_size()` scales the solver chunk size accordingly and
+`emergency_cleanup()` frees memory when consumption exceeds 85 %.  The
+loader can also derive optimal start hours via `get_smart_start_hours()`
+and limit permutations per shift with `max_patterns_per_shift`.
+
 ## Testing
 
 After installing the dependencies, run the test suite with:


### PR DESCRIPTION
## Summary
- add memory monitoring helpers and progress output
- refine scoring with efficiency bonus
- extend shift loader with smarter start times and per-shift limits
- implement adaptive chunk solver
- update tests for new features
- document memory-aware options in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c1ab4229c83278996e5b1a17a93d1