### PR TITLE
Use phased strategy for JEAN personalizado

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ Permite configurar de forma independiente los turnos **Full Time** y **Part Time
 Puedes ajustar los días laborables, la duración de la jornada y la ventana de
 break para cada tipo. El resto de parámetros del solver se fijan automáticamente
 según el perfil **JEAN**. Para Part Time la duración del break puede fijarse en
-0 horas si así lo requiere la normativa.
+0 horas si así lo requiere la normativa. Si se habilitan ambos contratos a la vez,
+el optimizador ejecuta una estrategia en dos fases que asigna los turnos **Full Time**
+sin exceso y luego completa la cobertura con los **Part Time**.
 
 ## JSON Template
 

--- a/generador_turnos_2025_cnx_BACKUP_F_FIRST_P_LAST (1).py
+++ b/generador_turnos_2025_cnx_BACKUP_F_FIRST_P_LAST (1).py
@@ -2343,9 +2343,18 @@ def optimize_jean_search(shifts_coverage, demand_matrix, target_coverage=98.0, m
 def optimize_schedule_iterative(shifts_coverage, demand_matrix):
     """Función principal con estrategia FT primero + PT después"""
     if PULP_AVAILABLE:
-        if optimization_profile in ("JEAN", "JEAN Personalizado"):
+        if optimization_profile == "JEAN":
             st.info("🔍 **Búsqueda JEAN**: cobertura sin exceso")
             return optimize_jean_search(shifts_coverage, demand_matrix, verbose=VERBOSE)
+
+        if optimization_profile == "JEAN Personalizado":
+            if use_ft and use_pt:
+                st.info("🏢⏰ **Estrategia 2 Fases**: FT sin exceso → PT para completar")
+                return optimize_ft_then_pt_strategy(shifts_coverage, demand_matrix)
+            else:
+                st.info("🔍 **Búsqueda JEAN**: cobertura sin exceso")
+                return optimize_jean_search(shifts_coverage, demand_matrix, verbose=VERBOSE)
+
         if use_ft and use_pt:
             st.info("🏢⏰ **Estrategia 2 Fases**: FT sin exceso → PT para completar")
             return optimize_ft_then_pt_strategy(shifts_coverage, demand_matrix)


### PR DESCRIPTION
## Summary
- switch optimize_schedule_iterative logic so JEAN Personalizado runs the two-phase strategy when both contract types are enabled
- document the new behaviour in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c3620249483278240381b5430ebbc