### PR TITLE
Refine JEAN Personalizado strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,9 @@ break para cada tipo. El resto de parámetros del solver se fijan automáticamen
 según el perfil **JEAN**. Para Part Time la duración del break puede fijarse en
 0 horas si así lo requiere la normativa. Si se habilitan ambos contratos a la vez,
 el optimizador ejecuta una estrategia en dos fases que asigna los turnos **Full Time**
-sin exceso y luego completa la cobertura con los **Part Time**.
+sin exceso y luego completa la cobertura con los **Part Time**. A continuación
+refina el resultado usando la búsqueda de puntuación **JEAN** para mejorar la
+ cobertura y el score.
 
 ## JSON Template
 

--- a/generador_turnos_2025_cnx_BACKUP_F_FIRST_P_LAST (1).py
+++ b/generador_turnos_2025_cnx_BACKUP_F_FIRST_P_LAST (1).py
@@ -2350,7 +2350,17 @@ def optimize_schedule_iterative(shifts_coverage, demand_matrix):
         if optimization_profile == "JEAN Personalizado":
             if use_ft and use_pt:
                 st.info("🏢⏰ **Estrategia 2 Fases**: FT sin exceso → PT para completar")
-                return optimize_ft_then_pt_strategy(shifts_coverage, demand_matrix)
+                assignments, method = optimize_ft_then_pt_strategy(shifts_coverage, demand_matrix)
+
+                results = analyze_results(assignments, shifts_coverage, demand_matrix)
+                if results:
+                    cov = results["coverage_percentage"]
+                    score = results["overstaffing"] + results["understaffing"]
+                    if cov < TARGET_COVERAGE or score > 0:
+                        st.info("♻️ **Refinando con búsqueda JEAN**")
+                        assignments, method = optimize_jean_search(shifts_coverage, demand_matrix, verbose=VERBOSE)
+
+                return assignments, method
             else:
                 st.info("🔍 **Búsqueda JEAN**: cobertura sin exceso")
                 return optimize_jean_search(shifts_coverage, demand_matrix, verbose=VERBOSE)


### PR DESCRIPTION
## Summary
- refine two-phase JEAN Personalizado using JEAN scoring search
- document new refinement behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c3d78fa8c83279b63707bb33032c5