### PR TITLE
Demand-weighted coverage calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ sin exceso y luego completa la cobertura con los **Part Time**. A continuación
 refina el resultado usando la búsqueda de puntuación **JEAN** para mejorar la
  cobertura y el score.
 
+The solver reports a `coverage_percentage` metric. This value is
+demand‑weighted: the total covered demand hours are divided by the total
+required hours, providing a more accurate view of how much of the
+workload is satisfied.
+
 ## JSON Template
 
 The **JEAN Personalizado** sidebar allows loading a configuration template in

--- a/generador_turnos_2025_cnx_BACKUP_F_FIRST_P_LAST (1).py
+++ b/generador_turnos_2025_cnx_BACKUP_F_FIRST_P_LAST (1).py
@@ -2741,7 +2741,11 @@ def generate_weekly_pattern_advanced(start_hour, duration, working_days, break_p
     return pattern.flatten()
 
 def analyze_results(assignments, shifts_coverage, demand_matrix):
-    """Analiza los resultados de la optimización"""
+    """Analiza los resultados de la optimización.
+
+    Calcula métricas como :data:`coverage_percentage`, que ahora
+    representa el porcentaje de demanda cubierta (ponderado por horas).
+    """
     if not assignments:
         return None
     
@@ -2770,9 +2774,9 @@ def analyze_results(assignments, shifts_coverage, demand_matrix):
             pt_agents += count
     
     # Calcular métricas
-    coverage_hours = (total_coverage > 0).sum()
-    required_hours = (demand_matrix > 0).sum()
-    coverage_percentage = (coverage_hours / required_hours * 100) if required_hours > 0 else 0
+    total_demand = demand_matrix.sum()
+    total_covered = np.minimum(total_coverage, demand_matrix).sum()
+    coverage_percentage = (total_covered / total_demand) * 100 if total_demand > 0 else 0
     
     # Calcular over/under staffing
     diff_matrix = total_coverage - demand_matrix


### PR DESCRIPTION
## Summary
- compute demand-weighted coverage percentage in `analyze_results`
- document that `coverage_percentage` is demand-weighted
- explain it in `analyze_results` docstring

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687c4160c83483279673ef1e93038cea